### PR TITLE
Fixing keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "description": "A Java WAR file generator plugin for Gulp",
   "keywords": [
-    "gulpplugin war"
+    "gulpplugin",
+    "war"
   ],
   "homepage": "https://github.com/ScottWeinstein/gulp-war",
   "bugs": "https://github.com/ScottWeinstein/gulp-war/issues",
@@ -36,9 +37,5 @@
     "node": ">=0.10.0",
     "npm": ">=1.2.10"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Keywords should be an array of strings.
Should now get added to http://gulpjs.com/plugins/ directory.
Should pass http://package-json-validator.com/ validator.
